### PR TITLE
Add helm release automation

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,20 @@
+---
+
+name: release helm chart
+on:
+  push:
+    tags: 'v[0-9]+.[0-9]+.*[0-9]*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          target_dir: ./deploy/godaddy-webhook
+          linting: off

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
-          target_dir: ./deploy/godaddy-webhook
+          charts_dir: ./deploy/
           linting: off

--- a/deploy/godaddy-webhook/Chart.yaml
+++ b/deploy/godaddy-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.24.0"
 description: A Helm chart for Kubernetes
 name: godaddy-webhook
-version: 1.24.0
+version: 1.24.2

--- a/deploy/godaddy-webhook/templates/deployment.yaml
+++ b/deploy/godaddy-webhook/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       volumes:
         - name: certs
           secret:

--- a/deploy/godaddy-webhook/templates/pki.yaml
+++ b/deploy/godaddy-webhook/templates/pki.yaml
@@ -23,7 +23,7 @@ metadata:
 {{ include "godaddy-webhook.labels" . | indent 4 }}
 spec:
   secretName: {{ include "godaddy-webhook.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "godaddy-webhook.selfSignedIssuer" . }}
   commonName: "ca.godaddy-webhook.cert-manager"
@@ -55,7 +55,7 @@ metadata:
 {{ include "godaddy-webhook.labels" . | indent 4 }}
 spec:
   secretName: {{ include "godaddy-webhook.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "godaddy-webhook.rootCAIssuer" . }}
   dnsNames:

--- a/deploy/godaddy-webhook/values.yaml
+++ b/deploy/godaddy-webhook/values.yaml
@@ -23,6 +23,9 @@ service:
   type: ClusterIP
   port: 443
 
+dnsPolicy: "default"
+dnsConfig: {}
+
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
## What
This PR adds a GitHub Action that releases the helm chart contained inside this repository's `deploy` directory into a `gh-pages` branch. That branch should then be set up by the repository owner in settings to generate a [GitHub page](https://github.com/Fred78290/cert-manager-webhook-godaddy/settings/pages).

## Motivation
Advanced CD tools (e.g. ArgoCD) need to have a chart repo to download helm charts from. It is not sufficient to only have a repository to build from. This PR establishes an automatic update procedure to generate such a helm chart repository for the single chart present herein on each tag push.