### PR TITLE
Adds support for extra environment variables

### DIFF
--- a/deploy/godaddy-webhook/Chart.yaml
+++ b/deploy/godaddy-webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.28.4"
+appVersion: "1.29.0"
 description: A Helm chart to install godaddy cert manager webhook
 name: godaddy-webhook
 version: 1.29.0

--- a/deploy/godaddy-webhook/Chart.yaml
+++ b/deploy/godaddy-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.28.4"
 description: A Helm chart to install godaddy cert manager webhook
 name: godaddy-webhook
-version: 1.28.4
+version: 1.29.0
 home: https://github.com/Fred78290/cert-manager-webhook-godaddy/
 icon: https://raw.githubusercontent.com/Fred78290/cert-manager-webhook-godaddy/master/images/cert-manager-godaddy.png
 keywords:

--- a/deploy/godaddy-webhook/templates/deployment.yaml
+++ b/deploy/godaddy-webhook/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName }}
+          {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/godaddy-webhook/values.yaml
+++ b/deploy/godaddy-webhook/values.yaml
@@ -33,3 +33,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+env: []


### PR DESCRIPTION
Hello,

I need to pass down HTTP_PROXY env variable to the deployment. The current helm chart does not allows this, hence the PR.

Did not touch the webhook code itself. The image works with the passed down http_proxy. Feel free to edit the versionsing. I've increased the minor version due to the new feature, but I beleive you want it consistent with the kubernetes versioning, so please update it as you wish.

Best,
Tomas